### PR TITLE
Added alt-w shortcut to search Perplexity for the current page

### DIFF
--- a/background.js
+++ b/background.js
@@ -25,8 +25,15 @@ chrome.action.onClicked.addListener(() => {
 });
 
 chrome.commands.onCommand.addListener((command) => {
+    console.log("Command received:", command);  // Add this line
     if (command === "toggle-search") {
         toggleSearch();
+    } else if (command === "search-page-content") {
+        console.log("Extracting page content...");  // Add this line
+        extractPageContent((content) => {
+            console.log("Content extracted:", content.substring(0, 50) + "...");  // Add this line
+            performSearch(content);
+        });
     }
 });
 
@@ -51,6 +58,53 @@ function performSearch(query) {
             chrome.tabs.create({ url: url });
         } else {
             chrome.tabs.update({ url: url });
+        }
+    });
+}
+
+function extractPageContent(callback) {
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+        if (tabs.length > 0) {
+            chrome.scripting.executeScript({
+                target: { tabId: tabs[0].id },
+                function: () => {
+                    // Get the page title
+                    const pageTitle = document.title;
+
+                    // Remove script and style elements
+                    const elementsToRemove = document.querySelectorAll('script, style, nav, header, footer');
+                    elementsToRemove.forEach(el => el.remove());
+
+                    // Get the main content
+                    const mainContent = document.querySelector('main') || document.body;
+                    
+                    // Extract and process the text
+                    let text = mainContent.innerText;
+                    
+                    // Remove extra whitespace and newlines
+                    text = text.replace(/\s+/g, ' ').trim();
+                    
+                    // Limit the length (e.g., to 1000 characters)
+                    const maxLength = 1000;
+                    if (text.length > maxLength) {
+                        text = text.substring(0, maxLength) + '...';
+                    }
+                    
+                    // Combine title, content, and URL
+                    return { title: pageTitle, content: text, url: window.location.href };
+                }
+            }, (result) => {
+                if (chrome.runtime.lastError) {
+                    console.error(chrome.runtime.lastError);
+                    callback('');
+                } else {
+                    const { title, content, url } = result[0].result;
+                    const formattedContent = `${title}\n\n${content}\n\n${url}`;
+                    callback(formattedContent);
+                }
+            });
+        } else {
+            callback('');
         }
     });
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
     "description": "Quickly search Perplexity with a keyboard shortcut or context menu",
     "permissions": [
         "activeTab",
+        "scripting",
         "storage",
         "contextMenus"
     ],
@@ -33,7 +34,14 @@
             "suggested_key": {
                 "default": "Alt+Q"
             },
-            "description": "Toggle Perplexity search input"
+            "description": "Toggle search"
+        },
+        "search-page-content": {
+            "suggested_key": {
+                "default": "Alt+W",
+                "mac": "Alt+W"
+            },
+            "description": "Search page content"
         }
     },
     "options_ui": {


### PR DESCRIPTION
This hotkey searches Perplexity with the current page. It sends the page title, first 1,000 characters or body text, and the URL. This is often enough to force Perplexity to load the page from its cache, and enough context for it to find similar content.